### PR TITLE
[maintenance] dependency upgrades 2022-03

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py39,pep8
+envlist = py39,pep8
 
 [testenv]
 deps = -r{toxinidir}/dev-requirements.txt


### PR DESCRIPTION
No packages to update this time around.

- Removed python 2.7 from tox.ini since python2 virtual environments don't work on ARM macs 